### PR TITLE
replace deprecated numpy function: np.asscalar -> .item() 

### DIFF
--- a/domainlab/tasks/utils_task.py
+++ b/domainlab/tasks/utils_task.py
@@ -229,7 +229,7 @@ def img_loader2dir(loader, folder, list_domain_na=None, list_class_na=None, batc
 
         for b_ind in range(img.shape[0]):
             class_label_ind = class_label_ind_batch[b_ind]
-            class_label_scalar = numpy.asscalar(class_label_ind)
+            class_label_scalar = class_label_ind.item()
 
             if list_class_na is None:
                 str_class_label = "class_"+str(class_label_scalar)

--- a/domainlab/utils/perf.py
+++ b/domainlab/utils/perf.py
@@ -55,5 +55,5 @@ class PerfClassif():
                 if i > max_batches:
                     break
         accuracy_y = fun_acc(list_vec_preds, list_vec_labels)
-        acc_y = np.asscalar(accuracy_y.cpu().numpy())
+        acc_y = accuracy_y.cpu().numpy().item()
         return acc_y


### PR DESCRIPTION
`np.asscalar` is deprecated since numpy version 1.16, Jan 2019. (https://numpy.org/doc/1.21/reference/generated/numpy.asscalar.html)